### PR TITLE
update CreateInBoundsGEP

### DIFF
--- a/Chapter03/calc/src/CodeGen.cpp
+++ b/Chapter03/calc/src/CodeGen.cpp
@@ -97,8 +97,8 @@ public:
           *M, StrText->getType(),
           /*isConstant=*/true, GlobalValue::PrivateLinkage,
           StrText, Twine(Var).concat(".str"));
-      Value *Ptr = Builder.CreateInBoundsGEP(
-          Str, {Int32Zero, Int32Zero}, "ptr");
+      Value *Ptr = Builder.CreateInBoundsGEP(nullptr, Str,
+                                             {Int32Zero, Int32Zero}, "ptr");
       CallInst *Call =
           Builder.CreateCall(ReadFty, ReadFn, {Ptr});
 


### PR DESCRIPTION
`CreateInBoundsGEP` without `Type*` interface has been deleted