### PR TITLE
fix example

### DIFF
--- a/Chapter03/calc/src/Lexer.cpp
+++ b/Chapter03/calc/src/Lexer.cpp
@@ -46,10 +46,10 @@ CASE('+', Token::plus);
 CASE('-', Token::minus);
 CASE('*', Token::star);
 CASE('/', Token::slash);
-CASE('(', Token::Token::l_paren);
-CASE(')', Token::Token::r_paren);
-CASE(':', Token::Token::colon);
-CASE(',', Token::Token::comma);
+CASE('(', Token::l_paren);
+CASE(')', Token::r_paren);
+CASE(':', Token::colon);
+CASE(',', Token::comma);
 #undef CASE
     default:
       formToken(token, BufferPtr + 1, Token::unknown);


### PR DESCRIPTION
```c++
#define CASE(ch, tok) \
case ch: formToken(token, BufferPtr + 1, tok); break
CASE('+', Token::plus);
CASE('-', Token::minus);
CASE('*', Token::star);
CASE('/', Token::slash);
CASE('(', Token::Token::l_paren);
CASE(')', Token::Token::r_paren);
CASE(':', Token::Token::colon);
CASE(',', Token::Token::comma);
#undef CASE
```
This is the code in the `Lexer::next` function in the `lexer.cpp` in Chapter 03. I think `Token::Token::op`  is something wrong .